### PR TITLE
Fix advanced settings editors for booleans and index pattern

### DIFF
--- a/src/kibana/components/index_patterns/_flatten_hit.js
+++ b/src/kibana/components/index_patterns/_flatten_hit.js
@@ -16,6 +16,6 @@ define(function (require) {
       }
     });
 
-    return hit.$$_flattened = _.merge(source, fields, _.pick(hit, self.metaFields));
+    return hit.$$_flattened = _.merge(source, fields, _.pick(hit, self.metaFields), _.pick(hit.fields, self.metaFields));
   };
 });

--- a/src/kibana/plugins/settings/sections/advanced/index.js
+++ b/src/kibana/plugins/settings/sections/advanced/index.js
@@ -47,7 +47,7 @@ define(function (require) {
 
             var editor = getEditorType(conf);
             conf.json = editor === 'json';
-            conf.bool = editor === 'bool';
+            conf.bool = editor === 'boolean';
             conf.array = editor === 'array';
             conf.normal = editor === 'normal';
             conf.tooComplex = !editor;

--- a/src/kibana/plugins/settings/sections/advanced/index.js
+++ b/src/kibana/plugins/settings/sections/advanced/index.js
@@ -1,6 +1,8 @@
 define(function (require) {
   var _ = require('lodash');
   var configDefaults = require('components/config/defaults');
+  var getValType = require('plugins/settings/sections/advanced/lib/get_val_type');
+
 
   require('plugins/settings/sections/advanced/advanced_row');
 
@@ -38,7 +40,7 @@ define(function (require) {
             var conf = {
               name: name,
               defVal: def.value,
-              type: (def.type || _.isArray(val) || typeof val),
+              type: getValType(def, val),
               description: def.description,
               value: val,
             };

--- a/src/kibana/plugins/settings/sections/advanced/lib/get_val_type.js
+++ b/src/kibana/plugins/settings/sections/advanced/lib/get_val_type.js
@@ -1,0 +1,22 @@
+define(function (require) {
+  var _ = require('lodash');
+
+  /**
+   * @param {object} advanced setting definition object
+   * @param {?} current value of the setting
+   * @returns {string} the type to use for determining the display and editor
+   */
+  function getValType(def, value) {
+    if (def.type) {
+      return def.type;
+    }
+
+    if (_.isArray(value) || _.isArray(def.value)) {
+      return 'array';
+    }
+
+    return (typeof def.value);
+  }
+
+  return getValType;
+});

--- a/src/kibana/plugins/settings/sections/advanced/lib/get_val_type.js
+++ b/src/kibana/plugins/settings/sections/advanced/lib/get_val_type.js
@@ -15,7 +15,7 @@ define(function (require) {
       return 'array';
     }
 
-    return (typeof def.value);
+    return (def.value != null ? typeof def.value : typeof value);
   }
 
   return getValType;

--- a/test/unit/specs/plugins/settings/sections/advanced/lib/get_val_type.js
+++ b/test/unit/specs/plugins/settings/sections/advanced/lib/get_val_type.js
@@ -1,0 +1,32 @@
+define(function (require) {
+  var getValType = require('plugins/settings/sections/advanced/lib/get_val_type');
+  describe('Settings', function () {
+    describe('Advanced', function () {
+      describe('getValType(def, val)', function () {
+        it('should be a function', function () {
+          expect(getValType).to.be.a(Function);
+        });
+
+        it('should return the explicitly defined type of a setting', function () {
+          expect(getValType({type: 'string'})).to.be('string');
+          expect(getValType({type: 'json'})).to.be('json');
+          expect(getValType({type: 'string', value: 5})).to.be('string');
+        });
+
+        it('should return array if the value is an Array and there is no defined type', function () {
+          expect(getValType({type: 'string'}, [1, 2, 3])).to.be('string');
+          expect(getValType({type: 'json', value: [1, 2, 3]})).to.be('json');
+
+          expect(getValType({value: 'someString'}, [1, 2, 3])).to.be('array');
+          expect(getValType({value: [1, 2, 3]}, 'someString')).to.be('array');
+
+        });
+
+        it('should return the type of the default value if there is no type and it is not an array', function () {
+          expect(getValType({value: 'someString'})).to.be('string');
+          expect(getValType({value: 'someString'}, 42)).to.be('string');
+        });
+      });
+    });
+  });
+});

--- a/test/unit/specs/plugins/settings/sections/advanced/lib/get_val_type.js
+++ b/test/unit/specs/plugins/settings/sections/advanced/lib/get_val_type.js
@@ -26,6 +26,10 @@ define(function (require) {
           expect(getValType({value: 'someString'})).to.be('string');
           expect(getValType({value: 'someString'}, 42)).to.be('string');
         });
+
+        it('should return the type of the value if the default value is null', function () {
+          expect(getValType({value: null}, 'someString')).to.be('string');
+        });
       });
     });
   });


### PR DESCRIPTION
This fixes the advanced editor for booleans and for advanced fields that have null defaults.

Closes #3340.
