### PR TITLE
Create shrinkwrap from build

### DIFF
--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -2,7 +2,6 @@ module.exports = function (grunt) {
   let { flatten } = require('lodash');
 
   grunt.registerTask('build', flatten([
-    '_build:shrinkwrap:ensureExists:true',
     '_build:getProps',
     'clean:build',
     'clean:target',
@@ -13,9 +12,8 @@ module.exports = function (grunt) {
     '_build:installedPlugins',
     '_build:packageJson',
     '_build:readme',
-    '_build:shrinkwrap:copyToBuild',
-    '_build:shrinkwrap:cleanup',
     '_build:installNpmDeps',
+    '_build:shrinkwrap:ensureExists:true',
     'clean:testsFromModules',
     'clean:deepModuleBins',
     'clean:deepModules',

--- a/tasks/build/shrinkwrap.js
+++ b/tasks/build/shrinkwrap.js
@@ -2,9 +2,10 @@ module.exports = function (grunt) {
   let { config } = grunt;
   let { statSync } = require('fs');
   let { join } = require('path');
-  let exec = (...args) => require('../utils/exec')(...args, { cwd: config.get('root') });
+  let buildDir = join(config.get('root'), 'build', 'kibana');
+  let exec = (...args) => require('../utils/exec')(...args, { cwd: buildDir });
   let newFiles = [];
-  let shrinkwrapFile = join(config.get('root'), 'npm-shrinkwrap.json');
+  let shrinkwrapFile = join(buildDir, 'npm-shrinkwrap.json');
 
   grunt.registerTask('_build:shrinkwrap:ensureExists', function (createIfMissing) {
     try {
@@ -18,24 +19,5 @@ module.exports = function (grunt) {
       }
       else grunt.fail.warn('Releases require an npm-shrinkwrap.json file to exist');
     }
-  });
-
-  grunt.registerTask('_build:shrinkwrap:copyToBuild', function () {
-    // this.requires(['_build:shrinkwrap:ensureExists', 'copy:devSource']);
-
-    // backup shrinkwrap and copy to build
-    exec('cp', ['npm-shrinkwrap.json', 'npm-shrinkwrap.dev']);
-    exec('cp', ['npm-shrinkwrap.json', join(config.get('root'), 'build', 'kibana', 'npm-shrinkwrap.build.json')]);
-
-    // create shrinkwrap without dev dependencies and copy to build
-    exec('npm', ['shrinkwrap', '--loglevel', 'error']);
-    exec('cp', ['npm-shrinkwrap.json', join(config.get('root'), 'build', 'kibana', 'npm-shrinkwrap.json')]);
-
-    // restore the dev shrinkwrap
-    exec('mv', ['npm-shrinkwrap.dev', 'npm-shrinkwrap.json']);
-  });
-
-  grunt.registerTask('_build:shrinkwrap:cleanup', function () {
-    if (newFiles.length) exec('rm', newFiles.splice(0));
   });
 };


### PR DESCRIPTION
The npm shrinkwrap that we generate during build in order to package
with distributions is now properly created based on the built
dependencies rather than the local dev install.